### PR TITLE
Replace deprecated PyQt exec_ usage with exec

### DIFF
--- a/davit/utils/hdf5_tree_view_model.py
+++ b/davit/utils/hdf5_tree_view_model.py
@@ -780,7 +780,7 @@ class HDF5TreeViewModel(QStandardItemModel):
         message_text = ("{}".format(xcp))
         message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self.parent.global_parent)
         message_box.setWindowIcon(QIcon(self.parent.global_parent.window_icon_path))
-        message_box.exec_()
+        message_box.exec()
 
         return
 
@@ -803,7 +803,7 @@ class HDF5TreeViewModel(QStandardItemModel):
         message_text = "The file cannot be opened because it is probably corrupted."
         message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self.parent.global_parent)
         message_box.setWindowIcon(QIcon(self.parent.global_parent.window_icon_path))
-        message_box.exec_()
+        message_box.exec()
 
         return
 

--- a/davit/views/analysis/histogram_tab.py
+++ b/davit/views/analysis/histogram_tab.py
@@ -137,7 +137,7 @@ class HistogramOptionsDialog(QDialog):
         if not selected_items:
             message_box = QMessageBox(QMessageBox.Icon.Warning, "No Selection", "Please select at least one column to plot.", parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.chart-bar"))
-            message_box.exec_()
+            message_box.exec()
             return
         options = {
             "selected_columns": [item.text() for item in selected_items],
@@ -338,7 +338,7 @@ class HistogramTab(QWidget):
         msg_box.setText(info_text)
         msg_box.setIcon(QMessageBox.Icon.Information)
         msg_box.setStyleSheet("QLabel { min-width: 800px; }")
-        msg_box.exec_()
+        msg_box.exec()
 
     #----------------------------------------------#
 
@@ -356,7 +356,7 @@ class HistogramTab(QWidget):
             default_density=self.options.get("density", False),
             default_show_kde=self.options.get("show_kde", True)
         )
-        self.options_dialog.exec_()
+        self.options_dialog.exec()
         return
 
     #----------------------------------------------#
@@ -441,7 +441,7 @@ class HistogramTab(QWidget):
         if not self.histogram_data:
             message_box = QMessageBox(QMessageBox.Icon.Critical, "Error", "No histogram data to save. Please run the analysis first.", parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # save the data
@@ -464,7 +464,7 @@ class HistogramTab(QWidget):
             message_text = f"The histogram data has been successfully saved to:\n{name}"
             message_box = QMessageBox(QMessageBox.Icon.Information, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         # display error
         except Exception as xcp:
@@ -472,7 +472,7 @@ class HistogramTab(QWidget):
             message_text = f"Unable to save results due to the following exception:\n{xcp}"
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 

--- a/davit/views/analysis/main_analysis.py
+++ b/davit/views/analysis/main_analysis.py
@@ -100,7 +100,7 @@ class MainAnalysis(QWidget):
             message_text = "Current dataframe has too many columns. Please, try to transpose it (top-right corner button) in order to properly analyze the data."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self.global_parent)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             self.too_many_columns = True
             self.setStyleSheet("QTabWidget{background-color: #F1A2A2;}")
 
@@ -269,7 +269,7 @@ class MainAnalysis(QWidget):
             message_text = "Unable to transpose the dataframe as the resulting matrix would have too many columns."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             if self.global_parent:
                 self.global_parent.auto_transpose = False
                 self.transpose_button.update_transpose_button_style(self.global_parent.auto_transpose)

--- a/davit/views/analysis/stats_tab.py
+++ b/davit/views/analysis/stats_tab.py
@@ -451,7 +451,7 @@ class StatsTab(QWidget):
         msg_box.setText(info_text)
         msg_box.setIcon(QMessageBox.Icon.Information)
         msg_box.setStyleSheet("QLabel { min-width: 800px; }")
-        msg_box.exec_()
+        msg_box.exec()
 
     #----------------------------------------------#
 
@@ -462,7 +462,7 @@ class StatsTab(QWidget):
             default_analysis_type=self.selected_analysis_type,
             default_column_names=self.column_names_option
         )
-        self.options_dialog.exec_()
+        self.options_dialog.exec()
         return
 
     #----------------------------------------------#
@@ -584,7 +584,7 @@ class StatsTab(QWidget):
             message_text = "Unable to run analysis because non-numeric columns were found."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.calculator"))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # for Bean Plot, do not allow if over max_n_columns numeric columns
@@ -594,7 +594,7 @@ class StatsTab(QWidget):
             message_text = "Cannot display Bean Plot when over {} columns are present.".format(self.max_n_columns)
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.calculator"))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # for Evolution Plot, require at least 2 numeric columns
@@ -603,7 +603,7 @@ class StatsTab(QWidget):
             message_text = "Evolution plot requires at least 2 numeric columns."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.calculator"))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # compute statistics
@@ -824,7 +824,7 @@ class StatsTab(QWidget):
             message_text = "Evolution plot requires at least 2 numeric columns."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.calculator"))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # reset tickers
@@ -902,7 +902,7 @@ class StatsTab(QWidget):
             message_text = "Unable to save analysis: No statistics computed."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # try catch block
@@ -945,7 +945,7 @@ class StatsTab(QWidget):
             message_text = f"The analysis has been successfully saved to:\n{name}"
             message_box = QMessageBox(QMessageBox.Icon.Information, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         # error
         except Exception as xcp:
@@ -953,7 +953,7 @@ class StatsTab(QWidget):
             message_text = "Unable to save analysis due to the following exception:\n{}".format(xcp)
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 

--- a/davit/views/analysis/svd_tab.py
+++ b/davit/views/analysis/svd_tab.py
@@ -182,7 +182,7 @@ class OptionsDialog(QDialog):
             message_text = ("n_modes cannot be larger than max_n_modes_to_display!")
             message_box = QMessageBox(QMessageBox.Icon.Warning, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.play-circle"))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # retrieve options
@@ -914,7 +914,7 @@ class SvdTab(QWidget):
         msg_box.setText(info_text)
         msg_box.setIcon(QMessageBox.Icon.Information)
         msg_box.setStyleSheet("QLabel { min-width: 800px; }")
-        msg_box.exec_()
+        msg_box.exec()
 
     #----------------------------------------------#
 
@@ -943,7 +943,7 @@ class SvdTab(QWidget):
 
         # open the dialog
         self.options_dialog = OptionsDialog(max_shape=self.dataframe.shape[1], unit=self.unit, options_dialog_info=self.options_dialog_info, parent=self, global_parent=self, max_n_modes_to_display=self.max_n_modes_to_display)
-        self.options_dialog.exec_()
+        self.options_dialog.exec()
 
         return
 
@@ -975,7 +975,7 @@ class SvdTab(QWidget):
             message_text = ("Unable to run analysis due to the following exception: {}".format(xcp))
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("fa5s.play-circle"))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # retrieve singular values and number of modes
@@ -1057,7 +1057,7 @@ class SvdTab(QWidget):
             message_text = ("No analysis found!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # typical try except workflow
@@ -1091,7 +1091,7 @@ class SvdTab(QWidget):
             message_text = ("The analysis has been successfully saved to the following path: {}".format(name))
             message_box = QMessageBox(QMessageBox.Icon.Information, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon(qta_icon))
-            message_box.exec_()
+            message_box.exec()
 
         # throw some error
         except Exception as xcp:
@@ -1101,7 +1101,7 @@ class SvdTab(QWidget):
             message_text = ("Unable to save the analysis due to: {}".format(xcp))
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon(qta_icon))
-            message_box.exec_()
+            message_box.exec()
 
         return
 

--- a/davit/views/general/filters_window.py
+++ b/davit/views/general/filters_window.py
@@ -294,7 +294,7 @@ class FiltersWindow(QDialog):
             message_text = "You have reached the maximum number of allowed filters!"
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("ri.play-list-add-fill"))
-            message_box.exec_()
+            message_box.exec()
 
         return
     
@@ -336,7 +336,7 @@ class FiltersWindow(QDialog):
             message_text = "At least one filter is needed!"
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon("ri.play-list-add-fill"))
-            message_box.exec_()
+            message_box.exec()
 
         return
 
@@ -399,7 +399,7 @@ class FiltersWindow(QDialog):
                 message_text = ("Successfully saved preset: {}".format(file_name))
                 message_box = QMessageBox(QMessageBox.Icon.Information, message_title, message_text, parent=self)
                 message_box.setWindowIcon(qta.icon("ri.play-list-add-fill"))
-                message_box.exec_()
+                message_box.exec()
 
         # save to parent
         else:

--- a/davit/views/general/hdf5_tree_view.py
+++ b/davit/views/general/hdf5_tree_view.py
@@ -256,7 +256,7 @@ class HDF5TreeView(QFrame):
                 self.menu_right_click_dict["open_analysis_in_new_window"].setEnabled(True)
 
         # update view
-        menu.exec_(self.treeView.viewport().mapToGlobal(position))
+        menu.exec(self.treeView.viewport().mapToGlobal(position))
 
         return
 

--- a/davit/views/general/main_window.py
+++ b/davit/views/general/main_window.py
@@ -556,7 +556,7 @@ class MainWindow(QMainWindow):
             message_text = ("No directory is currently loaded... Open a folder first!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # check if we have filters (for the moment reloadHDF5Treeview is disabled if we have filters applied)
@@ -565,7 +565,7 @@ class MainWindow(QMainWindow):
             message_text = ("Unable to reload with filters applied. Please deselect the filters and try reloading again.")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # empty last index
@@ -627,7 +627,7 @@ class MainWindow(QMainWindow):
 
             # open dialog
             self.filters_window = FiltersWindow(app=self.app, app_root_path=self.app_root_path, parent=self, current_filters_preset=self.current_filters_preset)
-            self.filters_window.exec_()
+            self.filters_window.exec()
 
         # message error
         else:
@@ -637,7 +637,7 @@ class MainWindow(QMainWindow):
             message_text = ("Unable to open filters until a valid file or directory has been loaded!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 
@@ -979,14 +979,14 @@ class MainWindow(QMainWindow):
                 message_text = ("Unable to perform {} operation because this merging is not implemented in pandas yet.".format(pandas_method))
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return
             except Exception  as xcp:
                 message_title = "Error"
                 message_text = ("Unable to perform {} operation due to the following exception: {}".format(pandas_method, xcp))
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return
 
             # set the window id
@@ -1213,14 +1213,14 @@ class MainWindow(QMainWindow):
                 message_text = ("Unable to perform {} operation because this merging is not implemented in pandas yet.".format(pandas_method))
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return
             except Exception  as xcp:
                 message_title = "Error"
                 message_text = ("Unable to perform {} operation due to the following exception: {}".format(pandas_method, xcp))
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return
 
             # set the window id
@@ -1504,7 +1504,7 @@ class MainWindow(QMainWindow):
                 message_text = "Not all children have the same number of elements. Unable to merge."
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return pd.DataFrame([])
 
             # create a DataFrame with each child array as a separate column
@@ -1518,7 +1518,7 @@ class MainWindow(QMainWindow):
                             "are not all scalars or all 1D arrays.")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return pd.DataFrame([])
 
     #----------------------------------------------#
@@ -1576,7 +1576,7 @@ class MainWindow(QMainWindow):
             )
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon((QIcon(self.window_icon_path)))
-            message_box.exec_()
+            message_box.exec()
             return None, None, None, "memory_error"
 
         # open waiting widget
@@ -2157,7 +2157,7 @@ class MainWindow(QMainWindow):
         )
         message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
         message_box.setWindowIcon(QIcon(self.window_icon_path))
-        message_box.exec_()
+        message_box.exec()
         return
 
     #----------------------------------------------#

--- a/davit/views/general/nxcals_threads_panel.py
+++ b/davit/views/general/nxcals_threads_panel.py
@@ -263,7 +263,7 @@ class NXCALSThreadsPanel(QDialog):
             globalPos = table.viewport().mapToGlobal(pos)
 
             # get the selected item
-            selectedItem = menu.exec_(globalPos)
+            selectedItem = menu.exec(globalPos)
 
         return
 
@@ -324,7 +324,7 @@ class NXCALSThreadsPanel(QDialog):
             message_text = ("The maximum number of threads has been reached. Please wait for some queries to finish.")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # start query in new thread

--- a/davit/views/general/nxcals_tree_view.py
+++ b/davit/views/general/nxcals_tree_view.py
@@ -323,7 +323,7 @@ class NXCALSTreeView(QFrame):
         self.layout_dialog_calendar.addWidget(self.calendar)
 
         # run dialog
-        self.dialog_calendar.exec_()
+        self.dialog_calendar.exec()
 
         return
 
@@ -366,7 +366,7 @@ class NXCALSTreeView(QFrame):
             message_text = ("Please, initialize PyTimber and run a valid query in order to open the NXCALS Threads panel.")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.threads_panel.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         return
@@ -501,7 +501,7 @@ class NXCALSTreeView(QFrame):
             message_text = ("Query format is not valid!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.threads_panel.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 
@@ -695,7 +695,7 @@ class NXCALSTreeView(QFrame):
                 self.menu_right_click_dict["remove_query"].setEnabled(False)
 
         # update view
-        menu.exec_(self.treeView.viewport().mapToGlobal(position))
+        menu.exec(self.treeView.viewport().mapToGlobal(position))
 
         return
 
@@ -794,7 +794,7 @@ class NXCALSTreeView(QFrame):
             message_text = ("Unable to init the NXCALS treeview as there are threads still running!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.threads_panel.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 

--- a/davit/views/general/postmortem_threads_panel.py
+++ b/davit/views/general/postmortem_threads_panel.py
@@ -260,7 +260,7 @@ class PostMortemThreadsPanel(QDialog):
             globalPos = table.viewport().mapToGlobal(pos)
 
             # get the selected item
-            selectedItem = menu.exec_(globalPos)
+            selectedItem = menu.exec(globalPos)
 
         return
 
@@ -295,7 +295,7 @@ class PostMortemThreadsPanel(QDialog):
             message_text = ("The maximum number of threads has been reached. Please wait for some queries to finish.")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             return
 
         # start query in new thread

--- a/davit/views/general/postmortem_tree_view.py
+++ b/davit/views/general/postmortem_tree_view.py
@@ -321,7 +321,7 @@ class PostMortemTreeView(QFrame):
         self.layout_dialog_calendar.addWidget(self.calendar)
 
         # run dialog
-        self.dialog_calendar.exec_()
+        self.dialog_calendar.exec()
 
         return
 
@@ -383,7 +383,7 @@ class PostMortemTreeView(QFrame):
             message_text = ("Query format is not valid!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.threads_panel.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 
@@ -552,7 +552,7 @@ class PostMortemTreeView(QFrame):
                 self.menu_right_click_dict["remove_query"].setEnabled(False)
 
         # update view
-        menu.exec_(self.treeView.viewport().mapToGlobal(position))
+        menu.exec(self.treeView.viewport().mapToGlobal(position))
 
         return
 
@@ -651,7 +651,7 @@ class PostMortemTreeView(QFrame):
             message_text = ("Unable to init the PostMortem treeview as there are threads still running!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.threads_panel.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 

--- a/davit/views/selection/main_selection.py
+++ b/davit/views/selection/main_selection.py
@@ -648,14 +648,14 @@ class MainSelection(QWidget):
                 message_text = ("Unable to perform {} operation because this merging is not implemented in pandas yet.".format(pandas_method))
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return
             except Exception  as xcp:
                 message_title = "Error"
                 message_text = ("Unable to perform {} operation due to the following exception: {}".format(pandas_method, xcp))
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
                 return
 
             # update the table
@@ -669,7 +669,7 @@ class MainSelection(QWidget):
             message_text = ("Dataset list is empty!")
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
 
         return
 
@@ -829,7 +829,7 @@ class MainSelection(QWidget):
             globalPos = table.viewport().mapToGlobal(pos)
 
             # get the selected item
-            selectedItem = menu.exec_(globalPos)
+            selectedItem = menu.exec(globalPos)
 
         return
 
@@ -967,7 +967,7 @@ class MainSelection(QWidget):
 
         # open the dialog
         self.slice_dialog = SliceDialog(key, row, df, df_before_slicing, parent=self, global_parent=self)
-        self.slice_dialog.exec_()
+        self.slice_dialog.exec()
 
         return
 
@@ -1104,7 +1104,7 @@ class MainSelection(QWidget):
             message_text = ("Dataframe has been successfully saved to the following path: {}".format(name))
             message_box = QMessageBox(QMessageBox.Icon.Information, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon(qta_icon))
-            message_box.exec_()
+            message_box.exec()
 
         # throw some error
         except Exception as xcp:
@@ -1114,7 +1114,7 @@ class MainSelection(QWidget):
             message_text = ("Unable to save dataframe due to: {}".format(xcp))
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(qta.icon(qta_icon))
-            message_box.exec_()
+            message_box.exec()
 
         return
 

--- a/davit/views/visualization/main_visualization.py
+++ b/davit/views/visualization/main_visualization.py
@@ -103,7 +103,7 @@ class MainVisualization(QWidget):
             message_text = "Current dataframe has too many columns. Please, try to transpose it (top-right corner button) in order to properly visualize the data."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self.global_parent)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             self.too_many_columns = True
             self.setStyleSheet("QTabWidget{background-color: #F1A2A2;}")
 
@@ -390,7 +390,7 @@ class MainVisualization(QWidget):
             message_text = "Unable to transpose the dataframe as the resulting matrix would have too many columns."
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
             if self.global_parent:
                 self.global_parent.auto_transpose = False
                 self.transpose_button.update_transpose_button_style(self.global_parent.auto_transpose)

--- a/davit/views/visualization/plot_tab.py
+++ b/davit/views/visualization/plot_tab.py
@@ -195,7 +195,7 @@ class PlotTab(QWidget):
             message_text = ("Unable to automatically set axes if the number of plots is larger than 9. Current number of selected plots: {}".format(len(axis_list)))
             message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
             message_box.setWindowIcon(QIcon(self.window_icon_path))
-            message_box.exec_()
+            message_box.exec()
         else:
             axis_list = [f"y{i}" for i in range(1, len(axis_list)+1)]
             if not self.var_axis_dict:
@@ -603,7 +603,7 @@ class PlotTab(QWidget):
 
         # run data selector dialog
         self.plot_data_selector = PlotDataSelector(self.dataframe, self.app, self.app_root_path, self, self.saved_selected_indexes, self.saved_names, self.saved_axis_list, self.var_axis_dict, x_label=self.x_label, y_label=self.y_label)
-        self.plot_data_selector.exec_()
+        self.plot_data_selector.exec()
 
         return
 
@@ -669,7 +669,7 @@ class PlotTab(QWidget):
                 message_text = "No curves to plot after all-zero removal."
                 message_box = QMessageBox(QMessageBox.Icon.Critical, message_title, message_text, parent=self)
                 message_box.setWindowIcon(QIcon(self.window_icon_path))
-                message_box.exec_()
+                message_box.exec()
 
                 # set back checkbox
                 QTimer.singleShot(0, lambda: self.checkBox_remove_all_zero_curves.setChecked(False))

--- a/scripts/reproduce_log_overflow.py
+++ b/scripts/reproduce_log_overflow.py
@@ -26,7 +26,7 @@ def main():
     plot_win.setLabel('left', 'Value')
 
     # start Qt event loop
-    app.exec_()
+    app.exec()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- replace deprecated PyQt6 `exec_()` calls with `exec()` across analysis and visualization dialogs
- update general view context menus and message boxes to use `exec()`
- adjust the reproduce_log_overflow script to start the Qt event loop with `app.exec()`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68caacc27d6c8322bbef3eac263f153f