### PR TITLE
Fix PyQt6 edit trigger usage in plot data selector

### DIFF
--- a/davit/views/visualization/plot_data_selector.py
+++ b/davit/views/visualization/plot_data_selector.py
@@ -113,7 +113,9 @@ class PlotDataSelector(QDialog):
         self.model_treeView.setHorizontalHeaderLabels(['Variable', 'Y-axis'])
 
         # set edit triggers
-        self.treeView.setEditTriggers(QTreeView.DoubleClicked | QTreeView.EditKeyPressed)
+        self.treeView.setEditTriggers(
+            QAbstractItemView.EditTrigger.DoubleClicked | QAbstractItemView.EditTrigger.EditKeyPressed
+        )
 
         # add children items (columns) to the parent item
         for row in self.columns:


### PR DESCRIPTION
## Summary
- replace the legacy QTreeView edit trigger flags with the scoped QAbstractItemView.EditTrigger values required by PyQt6

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd3ecb17348322ae395bcdfcf30c03