### PR TITLE
Fix HDF5 tree view expand/collapse operations

### DIFF
--- a/davit/views/general/hdf5_tree_view.py
+++ b/davit/views/general/hdf5_tree_view.py
@@ -556,9 +556,13 @@ class HDF5TreeView(QFrame):
     def expand_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.expand(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.expand_all(tree_view, [child_index])
 
     def expand_all_tracking(self, tree_view, indexes, expanded_indexes=None):
@@ -568,9 +572,13 @@ class HDF5TreeView(QFrame):
             if not tree_view.isExpanded(index):
                 tree_view.expand(index)
                 expanded_indexes.add(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.expand_all_tracking(tree_view, [child_index], expanded_indexes)
         return expanded_indexes
 
@@ -579,9 +587,13 @@ class HDF5TreeView(QFrame):
     def collapse_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.collapse(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.collapse_all(tree_view, [child_index])
 
     def collapse_all_tracking(self, tree_view, indexes, expanded_indexes):
@@ -589,9 +601,13 @@ class HDF5TreeView(QFrame):
             if index in expanded_indexes:
                 tree_view.collapse(index)
                 expanded_indexes.remove(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.collapse_all_tracking(tree_view, [child_index], expanded_indexes)
 
     #----------------------------------------------#


### PR DESCRIPTION
## Summary
- stop using the nonexistent QModelIndex.child helper in expand/collapse helpers
- look up child rows through the model to avoid AttributeError when expanding or collapsing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e38374062c8322856e8435900a7737