### PR TITLE
Fix expand/collapse traversal for NXCALS and PostMortem trees

### DIFF
--- a/davit/views/general/hdf5_tree_view.py
+++ b/davit/views/general/hdf5_tree_view.py
@@ -556,9 +556,13 @@ class HDF5TreeView(QFrame):
     def expand_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.expand(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.expand_all(tree_view, [child_index])
 
     def expand_all_tracking(self, tree_view, indexes, expanded_indexes=None):
@@ -568,9 +572,13 @@ class HDF5TreeView(QFrame):
             if not tree_view.isExpanded(index):
                 tree_view.expand(index)
                 expanded_indexes.add(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.expand_all_tracking(tree_view, [child_index], expanded_indexes)
         return expanded_indexes
 
@@ -579,9 +587,13 @@ class HDF5TreeView(QFrame):
     def collapse_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.collapse(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.collapse_all(tree_view, [child_index])
 
     def collapse_all_tracking(self, tree_view, indexes, expanded_indexes):
@@ -589,9 +601,13 @@ class HDF5TreeView(QFrame):
             if index in expanded_indexes:
                 tree_view.collapse(index)
                 expanded_indexes.remove(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.is_df_node(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.is_df_node(model, child_index):
                     self.collapse_all_tracking(tree_view, [child_index], expanded_indexes)
 
     #----------------------------------------------#

--- a/davit/views/general/nxcals_tree_view.py
+++ b/davit/views/general/nxcals_tree_view.py
@@ -938,9 +938,13 @@ class NXCALSTreeView(QFrame):
     def expand_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.expand(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.expand_all(tree_view, [child_index])
 
     def expand_all_tracking(self, tree_view, indexes, expanded_indexes=None):
@@ -950,9 +954,13 @@ class NXCALSTreeView(QFrame):
             if not tree_view.isExpanded(index):
                 tree_view.expand(index)
                 expanded_indexes.add(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.expand_all_tracking(tree_view, [child_index], expanded_indexes)
         return expanded_indexes
 
@@ -961,9 +969,13 @@ class NXCALSTreeView(QFrame):
     def collapse_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.collapse(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.collapse_all(tree_view, [child_index])
 
     def collapse_all_tracking(self, tree_view, indexes, expanded_indexes):
@@ -971,9 +983,13 @@ class NXCALSTreeView(QFrame):
             if index in expanded_indexes:
                 tree_view.collapse(index)
                 expanded_indexes.remove(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.collapse_all_tracking(tree_view, [child_index], expanded_indexes)
 
     #----------------------------------------------#

--- a/davit/views/general/postmortem_tree_view.py
+++ b/davit/views/general/postmortem_tree_view.py
@@ -795,9 +795,13 @@ class PostMortemTreeView(QFrame):
     def expand_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.expand(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.expand_all(tree_view, [child_index])
 
     def expand_all_tracking(self, tree_view, indexes, expanded_indexes=None):
@@ -807,9 +811,13 @@ class PostMortemTreeView(QFrame):
             if not tree_view.isExpanded(index):
                 tree_view.expand(index)
                 expanded_indexes.add(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.expand_all_tracking(tree_view, [child_index], expanded_indexes)
         return expanded_indexes
 
@@ -818,9 +826,13 @@ class PostMortemTreeView(QFrame):
     def collapse_all(self, tree_view, indexes):
         for index in indexes:
             tree_view.collapse(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.collapse_all(tree_view, [child_index])
 
     def collapse_all_tracking(self, tree_view, indexes, expanded_indexes):
@@ -828,9 +840,13 @@ class PostMortemTreeView(QFrame):
             if index in expanded_indexes:
                 tree_view.collapse(index)
                 expanded_indexes.remove(index)
-            for i in range(index.model().rowCount(index)):
-                child_index = index.child(i, 0)
-                if child_index.isValid() and not self.more_children(child_index.model(), child_index):
+            model = index.model()
+            if model is None:
+                continue
+            row_count = model.rowCount(index)
+            for i in range(row_count):
+                child_index = model.index(i, 0, index)
+                if child_index.isValid() and not self.more_children(model, child_index):
                     self.collapse_all_tracking(tree_view, [child_index], expanded_indexes)
 
     #----------------------------------------------#


### PR DESCRIPTION
## Summary
- look up child rows through the model in the NXCALS tree expand/collapse helpers to avoid QModelIndex.child usage
- update the PostMortem tree expand/collapse helpers to use model-derived child indexes as well

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38374062c8322856e8435900a7737